### PR TITLE
refactor: migrate to @ucdjs/ucd-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,5 +148,10 @@
     "tsdown": "^0.12.5",
     "typescript": "^5.8.3",
     "vscode-ext-gen": "^1.0.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "@luxass/utils": "npm:@luxass/utils@2.3.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       {
         "command": "ucd.visualize-file",
         "title": "Visualize UCD File",
-        "category": "UCD"
+        "category": "UCD",
+        "icon": "$(eye)"
       },
       {
         "command": "ucd.refresh-explorer",
@@ -112,6 +113,13 @@
           "command": "ucd.open-explorer-entry",
           "when": "viewItem == ucd:explorer-file || viewItem == ucd:explorer-folder || viewItem == ucd:version-folder",
           "group": "navigation"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "ucd.visualize-file",
+          "group": "navigation",
+          "when": "resourceScheme == ucd"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -128,10 +128,11 @@
   },
   "devDependencies": {
     "@luxass/eslint-config": "^4.18.1",
-    "@luxass/unicode-utils": "^0.12.0-beta.4",
+    "@luxass/unicode-utils": "^0.12.0-beta.5",
     "@reactive-vscode/vueuse": "^0.2.17",
     "@types/node": "^22.15.18",
     "@types/vscode": "^1.100.0",
+    "@ucdjs/ucd-store": "https://pkg.pr.new/@ucdjs/ucd-store@25",
     "@vscode/vsce": "^3.4.2",
     "eslint": "^9.27.0",
     "eslint-plugin-format": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,18 @@
     "configuration": {
       "title": "UCD",
       "properties": {
-        "ucd.local-data-files-store": {
+        "ucd.local-store-path": {
           "type": "string",
           "description": "Path to local UCD data file store",
           "default": ""
+        },
+        "ucd.store-filters": {
+          "type": "array",
+          "description": "Filters to apply on UCD Explorer",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         },
         "ucd.data-files-api": {
           "type": "string",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@luxass/utils': npm:@luxass/utils@2.3.0
+
 importers:
 
   .:
@@ -304,8 +307,8 @@ packages:
   '@luxass/unicode-utils@0.12.0-beta.5':
     resolution: {integrity: sha512-yzo+ETfvOOVOB2A4Oir2jX1wiM7f9ZE6KTxivDeTMi8eXo8Vbz8ktr2aiiCuTzwo6VZ7bNwHHtNdHa/XaneY7A==}
 
-  '@luxass/utils@2.2.1':
-    resolution: {integrity: sha512-riQdjsEXmHxaPDcWappVi1YYF/rsveZTvSIsev1m7qYQrRq6aRNYWTVVPhye3Pdf0NCWUNIKIdtrtpHhx+SgYA==}
+  '@luxass/utils@2.3.0':
+    resolution: {integrity: sha512-xzrw331cVMJ3yYLSXF15bPl6VDNlp+KudJ0h7wMJ1V30i0Ti+qnfWchwwetypEwifZitZ9XrydSq1XrEMi7d7Q==}
     engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@0.2.10':
@@ -505,6 +508,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
+
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
@@ -579,8 +585,8 @@ packages:
     resolution: {tarball: https://pkg.pr.new/@ucdjs/ucd-store@25}
     version: 0.0.1
 
-  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188':
-    resolution: {tarball: https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188}
+  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@8c880d7':
+    resolution: {tarball: https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@8c880d7}
     version: 0.1.0
 
   '@unrs/resolver-binding-darwin-arm64@1.7.8':
@@ -1617,6 +1623,10 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-network-error@1.1.0:
+    resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
+    engines: {node: '>=16'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2046,6 +2056,10 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -2244,6 +2258,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3004,10 +3022,12 @@ snapshots:
 
   '@luxass/unicode-utils@0.12.0-beta.5':
     dependencies:
-      '@luxass/utils': 2.2.1
+      '@luxass/utils': 2.3.0
       defu: 6.1.4
 
-  '@luxass/utils@2.2.1': {}
+  '@luxass/utils@2.3.0':
+    dependencies:
+      p-retry: 6.2.1
 
   '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
@@ -3226,6 +3246,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/retry@0.12.2': {}
+
   '@types/sarif@2.1.7': {}
 
   '@types/unist@3.0.3': {}
@@ -3335,14 +3357,14 @@ snapshots:
   '@ucdjs/ucd-store@https://pkg.pr.new/@ucdjs/ucd-store@25':
     dependencies:
       '@luxass/unicode-utils-new': '@luxass/unicode-utils@0.12.0-beta.5'
-      '@luxass/utils': 2.2.1
-      '@ucdjs/utils': https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188
+      '@luxass/utils': 2.3.0
+      '@ucdjs/utils': https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@8c880d7
       defu: 6.1.4
       fs-extra: 11.3.0
       micromatch: 4.0.8
       zod: 3.25.45
 
-  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188': {}
+  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@8c880d7': {}
 
   '@unrs/resolver-binding-darwin-arm64@1.7.8':
     optional: true
@@ -4433,6 +4455,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-network-error@1.1.0: {}
+
   is-number@7.0.0: {}
 
   is-wsl@3.1.0:
@@ -5035,6 +5059,12 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.1.0
+      retry: 0.13.1
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.3.0: {}
@@ -5252,6 +5282,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,20 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1(@typescript-eslint/utils@8.33.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       '@luxass/unicode-utils':
-        specifier: ^0.12.0-beta.4
-        version: 0.12.0-beta.4
+        specifier: ^0.12.0-beta.5
+        version: 0.12.0-beta.5
       '@reactive-vscode/vueuse':
         specifier: ^0.2.17
-        version: 0.2.17
+        version: 0.2.19
       '@types/node':
         specifier: ^22.15.18
         version: 22.15.29
       '@types/vscode':
         specifier: ^1.100.0
         version: 1.100.0
+      '@ucdjs/ucd-store':
+        specifier: https://pkg.pr.new/@ucdjs/ucd-store@25
+        version: https://pkg.pr.new/@ucdjs/ucd-store@25
       '@vscode/vsce':
         specifier: ^3.4.2
         version: 3.4.2
@@ -34,7 +37,7 @@ importers:
         version: 1.0.1(eslint@9.28.0(jiti@2.4.2))
       reactive-vscode:
         specifier: ^0.2.17
-        version: 0.2.17(@types/vscode@1.100.0)
+        version: 0.2.19(@types/vscode@1.100.0)
       tsdown:
         specifier: ^0.12.5
         version: 0.12.5(typescript@5.8.3)
@@ -298,8 +301,8 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@luxass/unicode-utils@0.12.0-beta.4':
-    resolution: {integrity: sha512-4Jj1rrxm2RjRTJU0N0Qec97ksqI9Fer4LS3cjJ+3nf+RAOW/Kjo9HaUxvY4DeL0J0jZ2VhWhoCzaNifGto5wlw==}
+  '@luxass/unicode-utils@0.12.0-beta.5':
+    resolution: {integrity: sha512-yzo+ETfvOOVOB2A4Oir2jX1wiM7f9ZE6KTxivDeTMi8eXo8Vbz8ktr2aiiCuTzwo6VZ7bNwHHtNdHa/XaneY7A==}
 
   '@luxass/utils@2.2.1':
     resolution: {integrity: sha512-riQdjsEXmHxaPDcWappVi1YYF/rsveZTvSIsev1m7qYQrRq6aRNYWTVVPhye3Pdf0NCWUNIKIdtrtpHhx+SgYA==}
@@ -331,19 +334,19 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@pkgr/core@0.2.4':
-    resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
+  '@pkgr/core@0.2.5':
+    resolution: {integrity: sha512-YRx7tFgLkrpFkDAzVSV5sUJydmf2ZDrW+O3IbQ1JyeMW7B0FiWroFJTnR4/fD9CsusnAn4qRUcbb5jFnZSd6uw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@quansync/fs@0.1.3':
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
     engines: {node: '>=20.0.0'}
 
-  '@reactive-vscode/reactivity@0.2.17':
-    resolution: {integrity: sha512-inEwa3aToCc9uyX9UmfuswqCbYHYErh7C/80IeZbHGgDTFt//Fe4lZxRNkxWwXGdHVi4AlBmnHqcbEP7tt1Bvw==}
+  '@reactive-vscode/reactivity@0.2.19':
+    resolution: {integrity: sha512-b8v4/Q1irXV5xREmsF8w3EpKp+WI/T29+aa74SBNrAnolC3qHslckGvj2/M12b2wcXmlVUVJl5mUHFpxjaAhHA==}
 
-  '@reactive-vscode/vueuse@0.2.17':
-    resolution: {integrity: sha512-liuR4bhIFBl8NXnoZygMN7s+AKzDmj+eaobNnelgERWL0tKtMTxVc1Mtr7Fl6rh+ivCCoipVIV3t+sp8Lvel9A==}
+  '@reactive-vscode/vueuse@0.2.19':
+    resolution: {integrity: sha512-gArQ8iBuCBSpfjWzvczD7PsMi2ODXhXrGJuF8YSB2qpk1Jtj9ORm6R36ZM9DCljvVyvWyrdreAdwb59OWRUcUA==}
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.10-commit.87188ed':
     resolution: {integrity: sha512-0tuZTzzjQ1TV5gcoRrIHfRRMyBqzOHL9Yl7BZX5iR+J2hIUBJiq1P+mGAvTb/PDgkYWfEgtBde3AUMJtSj8+Hg==}
@@ -572,6 +575,14 @@ packages:
     resolution: {integrity: sha512-Gz/Sm64+Sq/vklJu1tt9t+4R2lvnud8NbTD/ZfpZtMiUX7YeVpCA8j6NSW8ptwcoLL+NmYANwqP8DV0q/bwl2w==}
     engines: {node: '>=18.0.0'}
 
+  '@ucdjs/ucd-store@https://pkg.pr.new/@ucdjs/ucd-store@25':
+    resolution: {tarball: https://pkg.pr.new/@ucdjs/ucd-store@25}
+    version: 0.0.1
+
+  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188':
+    resolution: {tarball: https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188}
+    version: 0.1.0
+
   '@unrs/resolver-binding-darwin-arm64@1.7.8':
     resolution: {integrity: sha512-rsRK8T7yxraNRDmpFLZCWqpea6OlXPNRRCjWMx24O1V86KFol7u2gj9zJCv6zB1oJjtnzWceuqdnCgOipFcJPA==}
     cpu: [arm64]
@@ -789,9 +800,9 @@ packages:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
 
-  are-docs-informative@0.0.2:
-    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
-    engines: {node: '>=14'}
+  are-docs-informative@0.1.0:
+    resolution: {integrity: sha512-CplVvB5za1z5Zn528h0EUogt/McTT7lvHZKFtb2NYldodL7G3u2O49Mgws3mP/TrKhpNuDjKPHYxmh8t2DGTtQ==}
+    engines: {node: '>=18'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1053,11 +1064,11 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
-  dts-resolver@2.0.1:
-    resolution: {integrity: sha512-Pe2kqaQTNVxleYpt9Q9658fn6rEpoZbMbDpEBbcU6pnuGM3Q0IdM+Rv67kN6qcyp8Bv2Uv9NYy5Y1rG1LSgfoQ==}
+  dts-resolver@2.1.0:
+    resolution: {integrity: sha512-bgBo2md8jS5V11Rfhw23piIxJDEEDAnQ8hzh+jwKjX50P424IQhiZVVwyEe/n6vPWgEIe3NKrlRUyLMK9u0kaQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      oxc-resolver: ^9.0.2
+      oxc-resolver: '>=11.0.0'
     peerDependenciesMeta:
       oxc-resolver:
         optional: true
@@ -1220,8 +1231,8 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
-  eslint-plugin-jsdoc@50.6.17:
-    resolution: {integrity: sha512-hq+VQylhd12l8qjexyriDsejZhqiP33WgMTy2AmaGZ9+MrMWVqPECsM87GPxgHfQn0zw+YTuhqjUfk1f+q67aQ==}
+  eslint-plugin-jsdoc@50.7.0:
+    resolution: {integrity: sha512-fMeHWVtdxXvLfMmKLXJWObJSt57zBz31RCLZYj3bLSHBqnEsyO50N1OLDi5XP5wh+Gte5van9WTtOnemKAZrSw==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
@@ -1433,6 +1444,10 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2174,8 +2189,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  reactive-vscode@0.2.17:
-    resolution: {integrity: sha512-FIMLWJrGIjN1iSCL4LANwWhe9U1TXDUclKneJOGDl5lXoOnv9AokHdCVePW0X9VeBGP5419szyUxQHb26g3k6A==}
+  reactive-vscode@0.2.19:
+    resolution: {integrity: sha512-dqkuhOB0LmiTgODo3Uzn9UgkiuAgFxEdiuwlt6NKyPQWT5hOhfA862BFv4LnZM5fJXNyZ2XQ6INweroc5p8lfw==}
     peerDependencies:
       '@types/vscode': ^1.89.0
 
@@ -2653,6 +2668,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.45:
+    resolution: {integrity: sha512-kv1swJBZqv98NQibL0oVvkQE8rXT+6qGNM1FpZkFcJG2jnz4vbtu48bgaitp85CaBPLSKXibrEsU7MzJoVoZAA==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2954,7 +2972,7 @@ snapshots:
       eslint-merge-processors: 2.0.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-antfu: 3.1.1(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.15.0(@typescript-eslint/utils@8.33.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-jsdoc: 50.6.17(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-jsdoc: 50.7.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-jsonc: 2.20.1(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-n: 17.18.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-perfectionist: 4.13.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
@@ -2984,7 +3002,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@luxass/unicode-utils@0.12.0-beta.4':
+  '@luxass/unicode-utils@0.12.0-beta.5':
     dependencies:
       '@luxass/utils': 2.2.1
       defu: 6.1.4
@@ -3016,17 +3034,17 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@pkgr/core@0.2.4': {}
+  '@pkgr/core@0.2.5': {}
 
   '@quansync/fs@0.1.3':
     dependencies:
       quansync: 0.2.10
 
-  '@reactive-vscode/reactivity@0.2.17': {}
+  '@reactive-vscode/reactivity@0.2.19': {}
 
-  '@reactive-vscode/vueuse@0.2.17':
+  '@reactive-vscode/vueuse@0.2.19':
     dependencies:
-      '@reactive-vscode/reactivity': 0.2.17
+      '@reactive-vscode/reactivity': 0.2.19
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.10-commit.87188ed':
     optional: true
@@ -3314,6 +3332,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ucdjs/ucd-store@https://pkg.pr.new/@ucdjs/ucd-store@25':
+    dependencies:
+      '@luxass/unicode-utils-new': '@luxass/unicode-utils@0.12.0-beta.5'
+      '@luxass/utils': 2.2.1
+      '@ucdjs/utils': https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188
+      defu: 6.1.4
+      fs-extra: 11.3.0
+      micromatch: 4.0.8
+      zod: 3.25.45
+
+  '@ucdjs/utils@https://pkg.pr.new/ucdjs/ucd/@ucdjs/utils@862f188': {}
+
   '@unrs/resolver-binding-darwin-arm64@1.7.8':
     optional: true
 
@@ -3530,7 +3560,7 @@ snapshots:
 
   ansis@4.1.0: {}
 
-  are-docs-informative@0.0.2: {}
+  are-docs-informative@0.1.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3787,7 +3817,7 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  dts-resolver@2.0.1: {}
+  dts-resolver@2.1.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3937,10 +3967,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@50.6.17(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-jsdoc@50.7.0(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
-      are-docs-informative: 0.0.2
+      are-docs-informative: 0.1.0
       comment-parser: 1.4.1
       debug: 4.4.1
       escape-string-regexp: 4.0.0
@@ -4232,6 +4262,12 @@ snapshots:
     optional: true
 
   fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -5157,9 +5193,9 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  reactive-vscode@0.2.17(@types/vscode@1.100.0):
+  reactive-vscode@0.2.19(@types/vscode@1.100.0):
     dependencies:
-      '@reactive-vscode/reactivity': 0.2.17
+      '@reactive-vscode/reactivity': 0.2.19
       '@types/vscode': 1.100.0
 
   read-package-up@11.0.0:
@@ -5227,7 +5263,7 @@ snapshots:
       ast-kit: 2.1.0
       birpc: 2.3.0
       debug: 4.4.1
-      dts-resolver: 2.0.1
+      dts-resolver: 2.1.0
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.10-commit.87188ed
     optionalDependencies:
@@ -5424,7 +5460,7 @@ snapshots:
 
   synckit@0.11.8:
     dependencies:
-      '@pkgr/core': 0.2.4
+      '@pkgr/core': 0.2.5
 
   synckit@0.9.3:
     dependencies:
@@ -5694,5 +5730,7 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.45: {}
 
   zwitch@2.0.4: {}

--- a/src/composables/useUCDContentProvider.ts
+++ b/src/composables/useUCDContentProvider.ts
@@ -1,0 +1,9 @@
+import { useDisposable } from "reactive-vscode";
+import { workspace } from "vscode";
+import { UCDContentProvider } from "../lib/UCDContentProvider";
+
+export function useUCDContentProvider() {
+  const provider = new UCDContentProvider();
+  useDisposable(workspace.registerTextDocumentContentProvider("ucd", provider));
+  return provider;
+}

--- a/src/composables/useUCDStore.ts
+++ b/src/composables/useUCDStore.ts
@@ -7,16 +7,19 @@ export const useUCDStore = createSingletonComposable(() => {
 
   const createStoreFromConfig = async (localDataFilesStore: string | null) => {
     if (localDataFilesStore == null) {
-      return await createUCDStore("remote");
+      return await createUCDStore("remote", {
+        filters: config["store-filters"],
+      });
     } else {
       return await createUCDStore("local", {
         basePath: localDataFilesStore,
+        filters: config["store-filters"],
       });
     }
   };
 
   watch(
-    () => config["local-data-files-store"],
+    () => config["local-store-path"],
     async (newVal, oldVal) => {
       if (newVal === oldVal) {
         return;

--- a/src/composables/useUCDStore.ts
+++ b/src/composables/useUCDStore.ts
@@ -1,0 +1,36 @@
+import { createUCDStore } from "@ucdjs/ucd-store";
+import { createSingletonComposable, ref, watch } from "reactive-vscode";
+import { config } from "../config";
+
+export const useUCDStore = createSingletonComposable(() => {
+  const store = ref<Awaited<ReturnType<typeof createUCDStore>> | null>(null);
+
+  const createStoreFromConfig = async (localDataFilesStore: string | null) => {
+    if (localDataFilesStore == null) {
+      return await createUCDStore("remote");
+    } else {
+      return await createUCDStore("local", {
+        basePath: localDataFilesStore,
+      });
+    }
+  };
+
+  watch(
+    () => config["local-data-files-store"],
+    async (newVal, oldVal) => {
+      if (newVal === oldVal) {
+        return;
+      }
+
+      try {
+        store.value = await createStoreFromConfig(newVal);
+      } catch (error) {
+        console.error("Failed to create UCD store:", error);
+        store.value = null;
+      }
+    },
+    { immediate: true },
+  );
+
+  return store;
+});

--- a/src/composables/useUCDStore.ts
+++ b/src/composables/useUCDStore.ts
@@ -1,9 +1,7 @@
-import type { LocalUCDStore, RemoteUCDStore } from "@ucdjs/ucd-store";
+import type { LocalUCDStore, RemoteUCDStore, UCDStore } from "@ucdjs/ucd-store";
 import { createUCDStore } from "@ucdjs/ucd-store";
 import { createSingletonComposable, ref, watch } from "reactive-vscode";
 import { config } from "../config";
-
-export type UCDStore = RemoteUCDStore | LocalUCDStore;
 
 export const useUCDStore = createSingletonComposable(() => {
   const store = ref<UCDStore | null>(null);

--- a/src/composables/useUCDStore.ts
+++ b/src/composables/useUCDStore.ts
@@ -1,4 +1,4 @@
-import type { LocalUCDStore, RemoteUCDStore, UCDStore } from "@ucdjs/ucd-store";
+import type { UCDStore } from "@ucdjs/ucd-store";
 import { createUCDStore } from "@ucdjs/ucd-store";
 import { createSingletonComposable, ref, watch } from "reactive-vscode";
 import { config } from "../config";

--- a/src/composables/useUCDStore.ts
+++ b/src/composables/useUCDStore.ts
@@ -1,12 +1,15 @@
+import type { LocalUCDStore, RemoteUCDStore } from "@ucdjs/ucd-store";
 import { createUCDStore } from "@ucdjs/ucd-store";
 import { createSingletonComposable, ref, watch } from "reactive-vscode";
 import { config } from "../config";
 
-export const useUCDStore = createSingletonComposable(() => {
-  const store = ref<Awaited<ReturnType<typeof createUCDStore>> | null>(null);
+export type UCDStore = RemoteUCDStore | LocalUCDStore;
 
-  const createStoreFromConfig = async (localDataFilesStore: string | null) => {
-    if (localDataFilesStore == null) {
+export const useUCDStore = createSingletonComposable(() => {
+  const store = ref<UCDStore | null>(null);
+
+  const createStoreFromConfig = async (localDataFilesStore: string | null): Promise<UCDStore> => {
+    if (localDataFilesStore == null || localDataFilesStore.trim() === "") {
       return await createUCDStore("remote", {
         filters: config["store-filters"],
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import type { TreeViewNode } from "reactive-vscode";
 import type { UCDTreeItem } from "./views/ucd-explorer";
 import { defineExtension, executeCommand, useCommand } from "reactive-vscode";
 import { Uri } from "vscode";
+import { useUCDStore } from "./composables/useUCDStore";
 import * as Meta from "./generated/meta";
 import { getFilesByVersion } from "./lib/files";
 import { logger } from "./logger";
@@ -10,8 +11,9 @@ import { useUCDExplorer } from "./views/ucd-explorer";
 const { activate, deactivate } = defineExtension(async () => {
   useCommand(Meta.commands.browseUcdFiles, async () => {
     logger.info("Browsing UCD files...");
-    const view = await getFilesByVersion("16.0.0");
-    logger.info(`Fetched files for version 16.0.0: ${JSON.stringify(view, null, 2)}`);
+    const store = useUCDStore();
+    const data = await store.value?.getFilePaths("16.0.0");
+    logger.info(`Fetched files for version 16.0.0: ${JSON.stringify(data, null, 2)}`);
   });
 
   useCommand(Meta.commands.visualizeFile, () => {

--- a/src/lib/UCDContentProvider.ts
+++ b/src/lib/UCDContentProvider.ts
@@ -1,0 +1,22 @@
+import type { TextDocumentContentProvider, Uri } from "vscode";
+import { EventEmitter } from "vscode";
+import { logger } from "../logger";
+
+export class UCDContentProvider implements TextDocumentContentProvider {
+  onDidChangeEmitter = new EventEmitter<Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  async provideTextDocumentContent(uri: Uri) {
+    logger.info(`Providing content for URI: ${JSON.stringify(uri)}`);
+
+    const data = await fetch(`https://unicode-proxy.ucdjs.dev/${uri.path}`);
+    if (!data.ok) {
+      logger.error(`Failed to fetch UCD file: ${data.statusText}`);
+      return `Error fetching UCD file: ${data.statusText}`;
+    }
+
+    const text = await data.text();
+
+    return text;
+  }
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,5 +1,7 @@
 import type { UCDStore, UnicodeVersionFile } from "@ucdjs/ucd-store";
 import type { TreeViewNode } from "reactive-vscode";
+import type { UCDTreeItem } from "../views/ucd-explorer";
+import { hasUCDFolderPath } from "@luxass/unicode-utils";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import * as Meta from "../generated/meta";
 import { logger } from "../logger";
@@ -28,7 +30,11 @@ function mapEntryToTreeNode(version: string, entry: UnicodeVersionFile, parentPa
             },
           }
         : {}),
-    },
+      __ucd: {
+        version,
+        ucdUrl: `https://unicode.org/Public/${version}/${hasUCDFolderPath(version) ? "ucd/" : ""}${filePathForCommand}`,
+      },
+    } as UCDTreeItem,
     children: hasChildren ? entry.children?.map((child) => mapEntryToTreeNode(version, child, currentPath)) : [],
   };
 }

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,28 +1,42 @@
+import type { UCDStore, UnicodeVersionFile } from "@ucdjs/ucd-store";
 import type { TreeViewNode } from "reactive-vscode";
-import type { UCDStore } from "../composables/useUCDStore";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
-import { config } from "../config";
+import * as Meta from "../generated/meta";
 import { logger } from "../logger";
+
+function mapEntryToTreeNode(version: string, entry: UnicodeVersionFile, parentPath?: string): TreeViewNode {
+  const hasChildren = entry.children && entry.children.length > 0;
+  const currentPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+  const filePathForCommand = parentPath ? currentPath : entry.name;
+
+  return {
+    treeItem: {
+      iconPath: hasChildren ? new ThemeIcon("folder") : new ThemeIcon("file"),
+      label: entry.name,
+      collapsibleState: hasChildren ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
+      contextValue: hasChildren ? "ucd:explorer-folder" : "ucd:explorer-file",
+      ...(!hasChildren
+        ? {
+            command: {
+              command: Meta.commands.openExplorerEntry,
+              title: "Open UCD Data File",
+              arguments: [
+                version,
+                filePathForCommand,
+              ],
+              tooltip: "Open UCD data file for this version",
+            },
+          }
+        : {}),
+    },
+    children: hasChildren ? entry.children?.map((child) => mapEntryToTreeNode(version, child, currentPath)) : [],
+  };
+}
 
 export async function getFilesByVersion(store: UCDStore, version: string): Promise<TreeViewNode[]> {
   try {
-    // const data = await store.getFilePaths(version);
-    // return data.map((entry) => {
-    //   return {
-    //     treeItem: {
-    //       iconPath: entry.children?.length ? new ThemeIcon("folder") : new ThemeIcon("file"),
-    //       label: entry.name,
-    //       collapsibleState: entry.children?.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
-    //       contextValue: entry.children?.length ? "ucd:explorer-folder" : "ucd:explorer-file",
-    //     },
-    //     children: entry.children?.map((child) => ({
-    //       treeItem: {
-    //         label: child.name,
-    //       },
-    //     })) ?? [],
-    //   };
-    // });
-    return [];
+    const data = await store.getFileTree(version);
+    return data.map((entry) => mapEntryToTreeNode(version, entry));
   } catch (err) {
     logger.error(`Error fetching files for version ${version}:`, err);
     return [];

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,38 +1,28 @@
 import type { TreeViewNode } from "reactive-vscode";
+import type { UCDStore } from "../composables/useUCDStore";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import { config } from "../config";
 import { logger } from "../logger";
 
-export async function getFilesByVersion(version: string): Promise<TreeViewNode[]> {
+export async function getFilesByVersion(store: UCDStore, version: string): Promise<TreeViewNode[]> {
   try {
-    const res = await fetch(new URL(`/api/v1/unicode-files/${version}`, config["data-files-api"]));
-
-    if (!res.ok) {
-      throw new Error(`Failed to fetch files for version ${version}: ${res.statusText}`);
-    }
-
-    interface Entry {
-      name: string;
-      children?: Entry[];
-    }
-
-    const data = (await res.json()) as Entry[];
-
-    return data.map((entry) => {
-      return {
-        treeItem: {
-          iconPath: entry.children?.length ? new ThemeIcon("folder") : new ThemeIcon("file"),
-          label: entry.name,
-          collapsibleState: entry.children?.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
-          contextValue: entry.children?.length ? "ucd:explorer-folder" : "ucd:explorer-file",
-        },
-        children: entry.children?.map((child) => ({
-          treeItem: {
-            label: child.name,
-          },
-        })) ?? [],
-      };
-    });
+    // const data = await store.getFilePaths(version);
+    // return data.map((entry) => {
+    //   return {
+    //     treeItem: {
+    //       iconPath: entry.children?.length ? new ThemeIcon("folder") : new ThemeIcon("file"),
+    //       label: entry.name,
+    //       collapsibleState: entry.children?.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
+    //       contextValue: entry.children?.length ? "ucd:explorer-folder" : "ucd:explorer-file",
+    //     },
+    //     children: entry.children?.map((child) => ({
+    //       treeItem: {
+    //         label: child.name,
+    //       },
+    //     })) ?? [],
+    //   };
+    // });
+    return [];
   } catch (err) {
     logger.error(`Error fetching files for version ${version}:`, err);
     return [];

--- a/src/views/ucd-explorer.ts
+++ b/src/views/ucd-explorer.ts
@@ -35,7 +35,7 @@ export const useUCDExplorer = createSingletonComposable(() => {
     // create new loading promise
     const loadingPromise = (async () => {
       try {
-        const files = await getFilesByVersion(store.value, version);
+        const files = await getFilesByVersion(store.value!, version);
         childrenCache.value.set(version, files);
         return files;
       } catch (error) {

--- a/src/views/ucd-explorer.ts
+++ b/src/views/ucd-explorer.ts
@@ -3,6 +3,7 @@ import type { TreeItem } from "vscode";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils";
 import { computed, createSingletonComposable, ref, useTreeView } from "reactive-vscode";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
+import { useUCDStore } from "../composables/useUCDStore";
 import { getFilesByVersion } from "../lib/files";
 import { logger } from "../logger";
 
@@ -11,6 +12,8 @@ export interface UCDTreeItem extends TreeItem {
 }
 
 export const useUCDExplorer = createSingletonComposable(() => {
+  const store = useUCDStore();
+
   const childrenCache = ref<Map<string, TreeViewNode[]>>(new Map());
   const loadingPromises = ref<Map<string, Promise<TreeViewNode[]>>>(new Map());
 
@@ -29,7 +32,7 @@ export const useUCDExplorer = createSingletonComposable(() => {
     // create new loading promise
     const loadingPromise = (async () => {
       try {
-        const files = await getFilesByVersion(version);
+        const files = await getFilesByVersion(store.value, version);
         childrenCache.value.set(version, files);
         return files;
       } catch (error) {

--- a/src/views/ucd-explorer.ts
+++ b/src/views/ucd-explorer.ts
@@ -8,7 +8,10 @@ import { getFilesByVersion } from "../lib/files";
 import { logger } from "../logger";
 
 export interface UCDTreeItem extends TreeItem {
-  __ucd?: typeof UNICODE_VERSION_METADATA[number];
+  __ucd?: {
+    ucdUrl: string;
+    version: string;
+  };
 }
 
 export const useUCDExplorer = createSingletonComposable(() => {


### PR DESCRIPTION
This PR refactors implements a composable for a UCD Store, (https://github.com/ucdjs/ucd/pull/25).

This will allow us to support explorering data files locally, but at the same time remotely.
